### PR TITLE
Regex attribute for Matcher patterns

### DIFF
--- a/spacy/attrs.pxd
+++ b/spacy/attrs.pxd
@@ -86,5 +86,6 @@ cdef enum attr_id_t:
     SENT_START
     SPACY
     PROB
+    REGEX
 
     LANG

--- a/spacy/attrs.pyx
+++ b/spacy/attrs.pyx
@@ -89,6 +89,8 @@ IDS = {
     "SPACY": SPACY,
     "PROB": PROB,
     "LANG": LANG,
+
+    "REGEX": REGEX,
 }
 
 

--- a/spacy/lexeme.pxd
+++ b/spacy/lexeme.pxd
@@ -89,7 +89,7 @@ cdef class Lexeme:
             return lex.lang
         else:
             return 0
-    
+
     @staticmethod
     cdef inline bint c_check_flag(const LexemeC* lexeme, attr_id_t flag_id) nogil:
         cdef flags_t one = 1

--- a/spacy/matcher.pyx
+++ b/spacy/matcher.pyx
@@ -122,7 +122,6 @@ cdef TokenPatternC* init_pattern(Pool mem, attr_t entity_id,
             else:
                 pattern[i].attrs[j].value = value
                 pattern[i].attrs[j].is_regex = False
-                memset(&(pattern[i].attrs[j].regex), 0, sizeof(regex_t))
     i = len(token_specs)
     pattern[i].attrs = <AttrValueC*>mem.alloc(2, sizeof(AttrValueC))
     pattern[i].attrs[0].attr = ID

--- a/spacy/matcher.pyx
+++ b/spacy/matcher.pyx
@@ -119,7 +119,6 @@ cdef TokenPatternC* init_pattern(Pool mem, attr_t entity_id,
                 py_bytes = value.encode('utf-8')
                 regcomp(&(pattern[i].attrs[j].regex), py_bytes, REG_EXTENDED)
                 pattern[i].attrs[j].is_regex = True
-                pattern[i].attrs[j].value = -10
             else:
                 pattern[i].attrs[j].value = value
                 pattern[i].attrs[j].is_regex = False
@@ -151,7 +150,8 @@ cdef int get_action(const TokenPatternC* pattern, const TokenC* token, char* tok
     cdef attr_t token_attr_value
     for attr in pattern.attrs[:pattern.nr_attr]:
         token_attr_value = get_token_attr(token, attr.attr)
-        if token_attr_value != attr.value and (attr.is_regex == False or _regex_match(token_string, &(attr.regex)) == 0):
+        if (attr.is_regex == True and _regex_match(token_string, &(attr.regex)) == 0) or \
+            (attr.is_regex == False and token_attr_value != attr.value):
             if pattern.quantifier == ONE:
                 return REJECT
             elif pattern.quantifier == ZERO:

--- a/spacy/matcher.pyx
+++ b/spacy/matcher.pyx
@@ -4,12 +4,15 @@
 from __future__ import unicode_literals
 
 import ujson
+import re
 from cymem.cymem cimport Pool
 from preshed.maps cimport PreshMap
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from murmurhash.mrmr cimport hash64
 from libc.stdint cimport int32_t
+from libcpp cimport bool as cbool
+from libc.string cimport memset, strcpy, strlen
 
 from .typedefs cimport attr_t
 from .typedefs cimport hash_t
@@ -46,7 +49,19 @@ from .attrs import FLAG38 as L7_ENT
 from .attrs import FLAG37 as L8_ENT
 from .attrs import FLAG36 as L9_ENT
 from .attrs import FLAG35 as L10_ENT
+from .attrs import REGEX
 
+
+cdef extern from "regex.h" nogil:
+    ctypedef struct regmatch_t:
+       int rm_so
+       int rm_eo
+    ctypedef struct regex_t:
+       pass
+    int REG_EXTENDED
+    int regcomp(regex_t* preg, const char* regex, int cflags)
+    int regexec(const regex_t *preg, const char *string, size_t nmatch, regmatch_t pmatch[], int eflags)
+    void regfree(regex_t* preg)
 
 cpdef enum quantifier_t:
     _META
@@ -74,6 +89,8 @@ cdef enum action_t:
 cdef struct AttrValueC:
     attr_id_t attr
     attr_t value
+    regex_t regex
+    cbool is_regex
 
 
 cdef struct TokenPatternC:
@@ -90,13 +107,22 @@ cdef TokenPatternC* init_pattern(Pool mem, attr_t entity_id,
                                  object token_specs) except NULL:
     pattern = <TokenPatternC*>mem.alloc(len(token_specs) + 1, sizeof(TokenPatternC))
     cdef int i
+    cdef char * fancy_c_string
     for i, (quantifier, spec) in enumerate(token_specs):
         pattern[i].quantifier = quantifier
         pattern[i].attrs = <AttrValueC*>mem.alloc(len(spec), sizeof(AttrValueC))
         pattern[i].nr_attr = len(spec)
         for j, (attr, value) in enumerate(spec):
             pattern[i].attrs[j].attr = attr
-            pattern[i].attrs[j].value = value
+            if attr == REGEX:
+                py_bytes = value.encode('utf-8')
+                regcomp(&(pattern[i].attrs[j].regex), py_bytes, REG_EXTENDED)
+                pattern[i].attrs[j].is_regex = True
+                pattern[i].attrs[j].value = -10
+            else:
+                pattern[i].attrs[j].value = value
+                pattern[i].attrs[j].is_regex = False
+                memset(&(pattern[i].attrs[j].regex), 0, sizeof(regex_t))
     i = len(token_specs)
     pattern[i].attrs = <AttrValueC*>mem.alloc(2, sizeof(AttrValueC))
     pattern[i].attrs[0].attr = ID
@@ -104,6 +130,12 @@ cdef TokenPatternC* init_pattern(Pool mem, attr_t entity_id,
     pattern[i].nr_attr = 0
     return pattern
 
+cdef int _regex_match(char *token_string, regex_t *regex) nogil:
+    cdef int token_string_len = strlen(token_string)
+    cdef regmatch_t regmatch_obj[1]
+
+    nomatch = regexec(regex, token_string, 1, regmatch_obj, 0)
+    return 0 if nomatch else 1
 
 cdef attr_t get_pattern_key(const TokenPatternC* pattern) except 0:
     while pattern.nr_attr != 0:
@@ -112,12 +144,16 @@ cdef attr_t get_pattern_key(const TokenPatternC* pattern) except 0:
     assert id_attr.attr == ID
     return id_attr.value
 
-
-cdef int get_action(const TokenPatternC* pattern, const TokenC* token) nogil:
+cdef int get_action(const TokenPatternC* pattern, const TokenC* token, char* token_string) nogil:
     lookahead = &pattern[1]
+    cdef attr_t token_attr
+    cdef attr_t token_attr_value
     for attr in pattern.attrs[:pattern.nr_attr]:
-        if get_token_attr(token, attr.attr) != attr.value:
+        token_attr_value = get_token_attr(token, attr.attr)
+        if token_attr_value != attr.value:
             if pattern.quantifier == ONE:
+                if attr.is_regex and _regex_match(token_string, &(attr.regex)):
+                    return ACCEPT
                 return REJECT
             elif pattern.quantifier == ZERO:
                 return ACCEPT if lookahead.nr_attr == 0 else ADVANCE
@@ -134,7 +170,7 @@ cdef int get_action(const TokenPatternC* pattern, const TokenC* token) nogil:
     elif pattern.quantifier == ZERO_PLUS:
         # This is a bandaid over the 'shadowing' problem described here:
         # https://github.com/explosion/spaCy/issues/864
-        next_action = get_action(lookahead, token)
+        next_action = get_action(lookahead, token, token_string)
         if next_action is REJECT:
             return REPEAT
         else:
@@ -165,7 +201,7 @@ def _convert_strings(token_specs, string_store):
                     raise KeyError(msg % (value, ', '.join(operators.keys())))
             if isinstance(attr, basestring):
                 attr = IDS.get(attr.upper())
-            if isinstance(value, basestring):
+            if isinstance(value, basestring) and attr != REGEX:
                 value = string_store.add(value)
             if isinstance(value, bool):
                 value = int(value)
@@ -337,12 +373,13 @@ cdef class Matcher:
             # Go over the open matches, extending or finalizing if able.
             # Otherwise, we over-write them (q doesn't advance)
             for state in partials:
-                action = get_action(state.second, token)
+                token_string = self.vocab.strings[token.lex.orth].encode('utf-8')
+                action = get_action(state.second, token, token_string)
                 if action == PANIC:
                     raise Exception("Error selecting action in matcher")
                 while action == ADVANCE_ZERO:
                     state.second += 1
-                    action = get_action(state.second, token)
+                    action = get_action(state.second, token, token_string)
                 if action == PANIC:
                     raise Exception("Error selecting action in matcher")
 
@@ -369,12 +406,13 @@ cdef class Matcher:
             partials.resize(q)
             # Check whether we open any new patterns on this token
             for pattern in self.patterns:
-                action = get_action(pattern, token)
+                token_string = self.vocab.strings[token.lex.orth].encode('utf-8')
+                action = get_action(pattern, token, token_string)
                 if action == PANIC:
                     raise Exception("Error selecting action in matcher")
                 while action == ADVANCE_ZERO:
                     pattern += 1
-                    action = get_action(pattern, token)
+                    action = get_action(pattern, token, token_string)
                 if action == REPEAT:
                     state.first = token_i
                     state.second = pattern

--- a/spacy/matcher.pyx
+++ b/spacy/matcher.pyx
@@ -61,7 +61,6 @@ cdef extern from "regex.h" nogil:
     int REG_EXTENDED
     int regcomp(regex_t* preg, const char* regex, int cflags)
     int regexec(const regex_t *preg, const char *string, size_t nmatch, regmatch_t pmatch[], int eflags)
-    void regfree(regex_t* preg)
 
 
 cpdef enum quantifier_t:
@@ -108,7 +107,6 @@ cdef TokenPatternC* init_pattern(Pool mem, attr_t entity_id,
                                  object token_specs) except NULL:
     pattern = <TokenPatternC*>mem.alloc(len(token_specs) + 1, sizeof(TokenPatternC))
     cdef int i
-    cdef char * fancy_c_string
     for i, (quantifier, spec) in enumerate(token_specs):
         pattern[i].quantifier = quantifier
         pattern[i].attrs = <AttrValueC*>mem.alloc(len(spec), sizeof(AttrValueC))

--- a/spacy/tests/regression/test_issue1450.py
+++ b/spacy/tests/regression/test_issue1450.py
@@ -40,9 +40,6 @@ def test_issue1450_matcher_end_zero_plus(en_vocab, string, start, end):
     assert len(matches) == 1
     assert matches[0][1] == 4
     assert matches[0][2] == 5
-
-    ---------------------------
-    Changed the
     '''
     words = string.split()
     matcher = Matcher(en_vocab)

--- a/spacy/tests/regression/test_issue1450.py
+++ b/spacy/tests/regression/test_issue1450.py
@@ -4,6 +4,7 @@ import pytest
 from ...matcher import Matcher
 from ...tokens import Doc
 from ...vocab import Vocab
+from ..util import get_doc
 
 
 @pytest.mark.parametrize(
@@ -17,9 +18,9 @@ from ...vocab import Vocab
         ('a b b', 0, 2),
     ]
 )
-def test_issue1450_matcher_end_zero_plus(string, start, end):
+def test_issue1450_matcher_end_zero_plus(en_vocab, string, start, end):
     '''Test matcher works when patterns end with * operator.
-    
+
     Original example (rewritten to avoid model usage)
 
     nlp = spacy.load('en_core_web_sm')
@@ -39,8 +40,12 @@ def test_issue1450_matcher_end_zero_plus(string, start, end):
     assert len(matches) == 1
     assert matches[0][1] == 4
     assert matches[0][2] == 5
+
+    ---------------------------
+    Changed the
     '''
-    matcher = Matcher(Vocab())
+    words = string.split()
+    matcher = Matcher(en_vocab)
     matcher.add(
         "TSTEND",
         None,
@@ -49,10 +54,10 @@ def test_issue1450_matcher_end_zero_plus(string, start, end):
             {'ORTH': "b", 'OP': "*"}
         ]
     )
-    doc = Doc(Vocab(), words=string.split())
+    doc = get_doc(en_vocab, words)
     matches = matcher(doc)
     if start is None or end is None:
         assert matches == []
-    
+
     assert matches[0][1] == start
     assert matches[0][2] == end

--- a/spacy/tests/test_matcher.py
+++ b/spacy/tests/test_matcher.py
@@ -258,3 +258,25 @@ def test_matcher_end_zero_plus(matcher):
     assert len(matcher(nlp(u'a b c'))) == 1
     assert len(matcher(nlp(u'a b b c'))) == 1
     assert len(matcher(nlp(u'a b b'))) == 1
+
+
+@pytest.mark.parametrize('sentence, n_matches', [
+    (u'I am writing a cheeky test', 1),
+    (u'But it has failed in the past', 0),
+    (u'I\'m going to improve them though', 1),
+    (u'It had to be improved', 0)
+])
+def test_matcher_regex(matcher, sentence, n_matches):
+    '''Test matcher works with the REGEX attribute'''
+    matcher = Matcher(matcher.vocab)
+    matcher.add(
+        'VBG_TAG',
+        None,
+        [
+            {'REGEX': r'^[a-z]+ing$'}
+        ]
+    )
+    nlp = lambda sent: Doc(matcher.vocab, words=sent.split())
+    for m in matcher(nlp(sentence)):
+        print(m)
+    assert len(matcher(nlp(sentence))) == n_matches

--- a/spacy/tests/test_matcher.py
+++ b/spacy/tests/test_matcher.py
@@ -266,27 +266,7 @@ def test_matcher_end_zero_plus(matcher, sentence, n_matches):
 
 
 @pytest.mark.parametrize('sentence, n_matches', [
-    (u'I am writing a cheeky test', 1),
-    (u'But it has failed in the past', 0),
-    (u'I\'m going to improve them though', 1),
-    (u'It had to be improved', 0)
-])
-def test_matcher_regex(matcher, sentence, n_matches):
-    '''Test matcher works with the REGEX attribute'''
-    matcher = Matcher(matcher.vocab)
-    matcher.add(
-        'VBG_TAG',
-        None,
-        [
-            {'REGEX': r'^[a-z]+ing$'}
-        ]
-    )
-    words = sentence.split()
-    doc = get_doc(matcher.vocab, words)
-    assert len(matcher(doc)) == n_matches
-
-
-@pytest.mark.parametrize('sentence, n_matches', [
+    (u'a ababc x', 1),
     (u'a ab a', 1),
     (u'a aab a a ab c z', 2),
     (u'a aaaac a aab a a ab a', 2),
@@ -299,6 +279,11 @@ def test_matcher_regex_with_operators(matcher, sentence, n_matches):
     matcher.add(
         'VBG_TAG',
         None,
+        [
+            {'ORTH': 'a'},
+            {'REGEX': r'^[abc]+$'},
+            {'ORTH': 'x'},
+        ],
         [
             {'ORTH': 'a'},
             {'REGEX': r'^[a-z]+b$', 'OP': '+'},

--- a/spacy/tests/test_matcher.py
+++ b/spacy/tests/test_matcher.py
@@ -239,7 +239,17 @@ def test_operator_combos(matcher):
             assert not matches, (string, pattern_str)
 
 
-def test_matcher_end_zero_plus(matcher):
+@pytest.mark.parametrize(
+    'sentence, n_matches', [
+        (u'a', 1),
+        (u'a b', 1),
+        (u'a c', 1),
+        (u'a b c', 1),
+        (u'a b b c', 1),
+        (u'a b b', 1)
+    ]
+)
+def test_matcher_end_zero_plus(matcher, sentence, n_matches):
     '''Test matcher works when patterns end with * operator. (issue 1450)'''
     matcher = Matcher(matcher.vocab)
     matcher.add(
@@ -250,14 +260,9 @@ def test_matcher_end_zero_plus(matcher):
             {'ORTH': "b", 'OP': "*"}
         ]
     )
-    nlp = lambda string: Doc(matcher.vocab, words=string.split())
-    assert len(matcher(nlp(u'a'))) == 1
-    assert len(matcher(nlp(u'a b'))) == 1
-    assert len(matcher(nlp(u'a b'))) == 1
-    assert len(matcher(nlp(u'a c'))) == 1
-    assert len(matcher(nlp(u'a b c'))) == 1
-    assert len(matcher(nlp(u'a b b c'))) == 1
-    assert len(matcher(nlp(u'a b b'))) == 1
+    words = sentence.split()
+    doc = get_doc(matcher.vocab, words)
+    assert len(matcher(doc)) == 1
 
 
 @pytest.mark.parametrize('sentence, n_matches', [
@@ -276,7 +281,38 @@ def test_matcher_regex(matcher, sentence, n_matches):
             {'REGEX': r'^[a-z]+ing$'}
         ]
     )
-    nlp = lambda sent: Doc(matcher.vocab, words=sent.split())
-    for m in matcher(nlp(sentence)):
-        print(m)
-    assert len(matcher(nlp(sentence))) == n_matches
+    words = sentence.split()
+    doc = get_doc(matcher.vocab, words)
+    assert len(matcher(doc)) == n_matches
+
+
+@pytest.mark.parametrize('sentence, n_matches', [
+    (u'a ab a', 1),
+    (u'a aab a a ab c z', 2),
+    (u'a aaaac a aab a a ab a', 2),
+    (u'a ab c f fb b f b', 2),
+    (u'a z', 1)
+])
+def test_matcher_regex_with_operators(matcher, sentence, n_matches):
+    '''Test matcher works with the REGEX attribute and operators'''
+    matcher = Matcher(matcher.vocab)
+    matcher.add(
+        'VBG_TAG',
+        None,
+        [
+            {'ORTH': 'a'},
+            {'REGEX': r'^[a-z]+b$', 'OP': '+'},
+            {'ORTH': 'a'},
+        ],
+        [
+            {'ORTH': 'f'},
+            {'REGEX': r'^[a-z]+b$', 'OP': '*'},
+            {'ORTH': 'b'},
+        ],
+        [
+            {'ORTH': u'z', 'OP': '+'}
+        ]
+    )
+    words = sentence.split()
+    doc = get_doc(matcher.vocab, words)
+    assert len(matcher(doc)) == n_matches


### PR DESCRIPTION
## Description
We've added a new feature: `REGEX` flag/attribute for the Matcher patterns. It allows the users to use a regular expression to select/match a token in a pattern. Here's a simple example of a pattern including a regex attribute:
``` python
us_president_pattern = [
    {'LOWER': 'the'},
    {'REGEX': '^([Uu](\\.?|nited) ?[Ss](\\.?|tates)'},
    {'LOWER': 'president'}
]
```
The `REGEX` attribute should function just as the rest of the pattern attributes: it works in conjunction with operators, etc.

### Types of change
* a new feature was added to the Matcher
* some tests were added to support the feature
* some tests were improved as the new feature exposes some of their weaknesses

## Checklist
- [x] I have submitted the spaCy Contributor Agreement.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.

## TODO for release
- [x] Submit agreement
- [ ] Add more tests if necessary (@fran-babylon & @jack-babylon you're welcom to break it)
